### PR TITLE
Fix bug: https://github.com/qbittorrent/search-plugins/issues/274

### DIFF
--- a/tokyotoshokan.py
+++ b/tokyotoshokan.py
@@ -20,9 +20,9 @@ class tokyotoshokan(object):
 
     global page_count
     page_count = 1
+    name = 'Tokyo Toshokan'
 
     def __init__(self):
-        self.name = 'Tokyo Toshokan'
         self.supported_categories = {'all': '0', 'anime': '1', 'games': '14' }
         #self.supported_categories = {'all': '0', 'anime': '1', 'anime(non-english)': '10',
         #                        'manga': '3', 'drama': '8', 'music': '2',


### PR DESCRIPTION
Since last Python versions, Nova search engine has failed in loading TokyoToshokan plugin:

```
Could not parse Nova search engine capabilities, msg:  
Error: qBittorrent/nova3/engines/tokyotoshokan.py:40: SyntaxWarning: invalid escape sequence '\s'
  self.get_size_regex = re_compile(".*Size:\s+([^ ]*)\s+.*")
qBittorrent/nova3/engines/tokyotoshokan.py:103: SyntaxWarning: invalid escape sequence '\?'
  additional_links = re_compile("\?lastid=[0-9]+&page=[0-9]+&terms={}".format(query.replace('%20', '\\+')))
Traceback (most recent call last):
  File "qBittorrent/nova3/nova2.py", line 267, in <module>
    main(sys.argv[1:])
  File "qBittorrent/nova3/nova2.py", line 225, in main
    displayCapabilities(supported_engines)
  File "qBittorrent/nova3/nova2.py", line 173, in displayCapabilities
    "".join(engines_to_xml(supported_engines)),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "qBittorrent/nova3/nova2.py", line 155, in engines_to_xml
    tab, tab, "<name>", search_engine.name, "</name>\n",
                        ^^^^^^^^^^^^^^^^^^
AttributeError: type object 'tokyotoshokan' has no attribute 'name'
```

I have just promoted 'name' attribute from instance to class attribute.