### PR TITLE
Update tokyotoshokan.py to start in qBittorrent.

### DIFF
--- a/tokyotoshokan.py
+++ b/tokyotoshokan.py
@@ -17,14 +17,16 @@ from helpers import download_file, retrieve_url
 
 class tokyotoshokan(object):
     url = 'http://tokyotosho.info'
-
+    name = 'Tokyo Toshokan'
+    supported_categories = {'all': '0', 'anime': '1', 'games': '14' }
+        
     global page_count
     page_count = 1
 
     def __init__(self):
-        self.name = 'Tokyo Toshokan'
-        self.supported_categories = {'all': '0', 'anime': '1', 'games': '14' }
-        #self.supported_categories = {'all': '0', 'anime': '1', 'anime(non-english)': '10',
+        # self.name = 'Tokyo Toshokan'
+        # self.supported_categories = {'all': '0', 'anime': '1', 'games': '14' }
+        # self.supported_categories = {'all': '0', 'anime': '1', 'anime(non-english)': '10',
         #                        'manga': '3', 'drama': '8', 'music': '2',
         #                        'music video': '9', 'raw': '7', 'hentai': '4',
         #                        'eroge': '14', 'batch': '11', 'jav': '15', 'other': '5'}


### PR DESCRIPTION
qBittorrent expects the search engine class to have `name` as a  class attribute, not as an instance attribute.